### PR TITLE
[PASST-2376] feature flipper enable_extended_loan_types removed

### DIFF
--- a/docs/de_howto_maximum-offer.md
+++ b/docs/de_howto_maximum-offer.md
@@ -8,7 +8,6 @@ Zur Aktivierung der Maximal-Preis-Ermittlung ist in den Metadaten der dafür not
 {
     "metadaten": {
         "datenkontext": "TEST_MODUS",
-        "feature": "enable_extended_loan_types",
         "mode": "maximum-offer"
     }
 }


### PR DESCRIPTION
[PASST-2376] feature flipper enable_extended_loan_types removed

[PASST-2376]: https://europace.atlassian.net/browse/PASST-2376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ