### PR TITLE
chore: optimize dependabot config to reduce PR noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,14 +4,46 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Europe/Berlin"
     commit-message:
       prefix: "gh actions"
     open-pull-requests-limit: 1
+    cooldown:
+      default-days: 5
+      semver-major-days: 21
+      semver-minor-days: 7
+      semver-patch-days: 3
+    groups:
+      minor-and-patch-updates:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "gradle"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Europe/Berlin"
     commit-message:
       prefix: "gradle"
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 5
+      semver-major-days: 21
+      semver-minor-days: 7
+      semver-patch-days: 3
+    groups:
+      minor-and-patch-updates:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary
Optimize the existing Dependabot configuration for the ecosystems actually used in this repository.

## What changed
- switch checks to a fixed weekly schedule on Monday at 09:00 Europe/Berlin
- add cooldown windows for fresh releases
- group minor and patch updates while leaving major updates isolated
- keep the existing GitHub Actions and Gradle scopes